### PR TITLE
Windows fixes

### DIFF
--- a/elsepa/executable.py
+++ b/elsepa/executable.py
@@ -73,7 +73,7 @@ class SimpleExecutable(object):
         return result
 
 
-def build_image(client: docker.Client, path: str, name: str):
+def build_image(client: docker.APIClient, path: str, name: str):
     """Build the Docker image as per Dockerfile present in <path>.
     If the docker image with given name is newer than the Dockerfile,
     nothing is done.
@@ -161,7 +161,7 @@ class DockerContainer(object):
     same container upon exit.
     """
 
-    client = docker.Client()
+    client = docker.APIClient()
 
     def __init__(self, image, working_dir=None):
         self.image = image

--- a/elsepa/executable.py
+++ b/elsepa/executable.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+import posixpath
 import sys
 
 try:
@@ -85,8 +86,8 @@ def build_image(client: docker.APIClient, path: str, name: str):
     :param name:
         Name of the image
     """
-    assert os.path.exists(path + '/Dockerfile')
-    time = os.stat(path + '/Dockerfile').st_mtime
+    assert os.path.exists(os.path.join(path, 'Dockerfile'))
+    time = os.stat(os.path.join(path, 'Dockerfile')).st_mtime
 
     il = client.images(name=name)
     if len(il) == 0 or il[0]['Created'] < time:
@@ -185,7 +186,7 @@ class DockerContainer(object):
         :type path: str
         """
         if self.working_dir is not None:
-            path = os.path.join(self.working_dir, path)
+            path = posixpath.join(self.working_dir, path)
 
         self.client.put_archive(
             self.container_id, path, archive.buffer)
@@ -193,8 +194,8 @@ class DockerContainer(object):
     def get_archive(self, path):
         """Get a file or directory from the container and make it into
         an `Archive` object."""
-        if self.working_dir is not None and not os.path.isabs(path):
-            path = os.path.join(self.working_dir, path)
+        if self.working_dir is not None and not posixpath.isabs(path):
+            path = posixpath.join(self.working_dir, path)
 
         strm, stat = self.client.get_archive(
             self.container_id, path)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering :: Physics'],
     install_requires=[
-        'pint', 'numpy', 'docker-py', 'cslib', 'noodles[prov,numpy]'],
+        'pint', 'numpy', 'docker', 'cslib', 'noodles[prov,numpy]'],
     extras_require={
         'test': ['pytest']
     },


### PR DESCRIPTION
* In docker-py 2.0, `docker.Client` was renamed to `docker.APIClient`, and the pip package `docker-py` was renamed to `docker`. ([changelog](https://docker-py.readthedocs.io/en/stable/change-log.html))
* Make sure we don't mix Docker host and container OS paths.