### PR TITLE
Add option to run a local ELSEPA instance, without Docker

### DIFF
--- a/elsepa/run.py
+++ b/elsepa/run.py
@@ -3,30 +3,54 @@ from elsepa.parse_output import (elsepa_output_parsers)
 from elsepa.executable import (DockerContainer, Archive)
 
 import re
+import os
+import glob
+import subprocess
 
 
 def elscata(settings: Settings):
-    with DockerContainer('elsepa', working_dir='/opt/elsepa') as elsepa:
-        elsepa.put_archive(
-            Archive('w')
-            .add_text_file('input.dat', generate_elscata_input(settings))
-            .close())
+    elsepa_dir = os.getenv('ELSEPA_DIR')
+    result = {}
 
-        elsepa.sh('./elscata < input.dat',
-                  'mkdir result && mv *.dat result')
+    if elsepa_dir:
+        os.chdir(elsepa_dir)
+        for fn in glob.glob('*.dat'):
+            os.remove(fn)
 
-        result_tar = elsepa.get_archive('result')
-        result = {}
+        subprocess.run('./elscata',
+                       input=bytes(generate_elscata_input(settings), 'utf-8'),
+                       stdout=subprocess.DEVNULL)
 
-        for info in result_tar:
-            if not info.isfile():
-                continue
-
-            name = re.match("result/(.*)\\.dat", info.name).group(1)
+        for fn in glob.glob('*.dat'):
+            name = re.match("(.*)\\.dat", fn).group(1)
             parser = elsepa_output_parsers[name]
 
             if parser:
-                lines = result_tar.get_text_file(info).split('\n')
+                with open(fn, "r") as f:
+                    lines = f.readlines()
                 result[name] = parser(lines)
+
+    else:
+        with DockerContainer('elsepa', working_dir='/opt/elsepa') as elsepa:
+            elsepa.put_archive(
+                Archive('w')
+                .add_text_file('input.dat', generate_elscata_input(settings))
+                .close())
+
+            elsepa.sh('./elscata < input.dat',
+                      'mkdir result && mv *.dat result')
+
+            result_tar = elsepa.get_archive('result')
+
+            for info in result_tar:
+                if not info.isfile():
+                    continue
+
+                name = re.match("result/(.*)\\.dat", info.name).group(1)
+                parser = elsepa_output_parsers[name]
+
+                if parser:
+                    lines = result_tar.get_text_file(info).split('\n')
+                    result[name] = parser(lines)
 
     return result


### PR DESCRIPTION
Draft. Comments welcome.

* Is the "SimpleExecutable" wrapper worth it? I think the only thing it needs to do is call `subprocess.run()`.
* We should do better dependency checking, e.g. allow installation without Docker, and fail at runtime if it not available when `ELSEPA_DIR` is not set.