### PR TITLE
change docker interface to newer docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.pytest_cache/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -93,3 +94,4 @@ ENV/
 .*.swp
 .*.swo
 
+docker/adus*

--- a/elsepa/run.py
+++ b/elsepa/run.py
@@ -6,13 +6,13 @@ import re
 
 
 def elscata(settings: Settings):
-    with DockerContainer('elsepa', working_dir='/opt/elsepa') as elsepa:
+    with DockerContainer('elsepa', working_dir='/root') as elsepa:
         elsepa.put_archive(
             Archive('w')
             .add_text_file('input.dat', generate_elscata_input(settings))
             .close())
 
-        elsepa.sh('./elscata < input.dat',
+        elsepa.sh('elscata < input.dat',
                   'mkdir result && mv *.dat result')
 
         result_tar = elsepa.get_archive('result')

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering :: Physics'],
     install_requires=[
-        'pint==0.8.1', 'numpy==1.13.0', 'docker==2.4.0', 'cslib', 'noodles[prov,numpy]==0.2.3'],
+        'pint==0.8.1', 'numpy==1.13.0', 'docker==2.4.0', 'cslib', 'noodles'],
     extras_require={
         'test': ['pytest']
     },


### PR DESCRIPTION
This sets the use of the docker interface to the docker image that is build using the Docker file in the project root.